### PR TITLE
docs: clarify AWS AppConfig object type limitations

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -7,7 +7,7 @@ AWS AppConfigと統合してフィーチャーフラグ管理を行うOpenFeatur
 - ✅ OpenFeature仕様の完全準拠
 - ✅ AWS AppConfig統合（最新のAppConfigData API使用）
 - ✅ AppConfig Agentと直接SDKの併存サポート
-- ✅ 全データ型のサポート（boolean、string、number、object）
+- ✅ 全データ型のサポート（boolean、string、number、object） - 注意: AWS AppConfigはネイティブでboolean、string、number、配列をサポートしています。オブジェクト型はJSON文字列として保存し、クライアント側でパースします。
 - ✅ 包括的なエラーハンドリング
 - ✅ 型変換とバリデーション
 - ✅ モックを使用したユニットテスト
@@ -204,12 +204,11 @@ bundle exec rake test
   "feature-flag": true,
   "welcome-message": "Hello World!",
   "max-retries": 5,
-  "user-config": {
-    "theme": "dark",
-    "language": "en"
-  }
+  "user-config": "{\"theme\": \"dark\", \"language\": \"en\"}"
 }
 ```
+
+**注意**: AWS AppConfigはネイティブでboolean、string、number、配列をサポートしています。オブジェクト型については、AWS AppConfigにJSON文字列として保存してください。プロバイダーは`get_object_value()`を使用する際に自動的にJSON文字列をオブジェクトにパースします。
 
 ### AWS AppConfigセットアップ
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Ruby provider for OpenFeature that integrates with AWS AppConfig for feature f
 
 - ✅ Full OpenFeature specification compliance
 - ✅ AWS AppConfig integration using the latest AppConfigData API
-- ✅ Support for all data types (boolean, string, number, object)
+- ✅ Support for all data types (boolean, string, number, object) - Note: AWS AppConfig natively supports boolean, string, number, and arrays. Object types are handled by storing JSON strings and parsing them client-side.
 - ✅ **Multi-variant feature flags with targeting rules**
 - ✅ **Advanced targeting operators (equals, contains, starts_with, etc.)**
 - ✅ **Complex targeting conditions with multiple attributes**
@@ -224,12 +224,11 @@ bundle exec rake test
   "feature-flag": true,
   "welcome-message": "Hello World!",
   "max-retries": 5,
-  "user-config": {
-    "theme": "dark",
-    "language": "en"
-  }
+  "user-config": "{\"theme\": \"dark\", \"language\": \"en\"}"
 }
 ```
+
+**Note**: AWS AppConfig natively supports boolean, string, number, and arrays. For object types, store them as JSON strings in AWS AppConfig. The provider will automatically parse JSON strings into objects when using `get_object_value()`.
 
 ### Multi-Variant Feature Flags
 


### PR DESCRIPTION
## Summary

This PR clarifies the limitations of AWS AppConfig regarding object type support and updates the documentation accordingly.

## Changes

- **README.md**: Added note about AWS AppConfig native data type support
- **README-ja.md**: Added corresponding Japanese documentation
- Updated examples to show JSON string format for object types
- Explained that the provider automatically parses JSON strings to objects

## Background

According to [AWS AppConfig documentation](https://docs.aws.amazon.com/ja_jp/appconfig/latest/userguide/appconfig-creating-configuration-and-profile-feature-flags.html), AWS AppConfig natively supports:
- Boolean
- String  
- Number
- String arrays
- Number arrays

**Object types (JSON objects) are not natively supported** and must be stored as JSON strings in AWS AppConfig.

## Implementation Details

The provider's `resolve_object_value` method handles this limitation by:
1. Accepting JSON strings from AWS AppConfig
2. Automatically parsing them into Ruby Hash objects
3. Providing a seamless experience for users

## Example

```json
// AWS AppConfig configuration
{
  "user-config": "{\"theme\": \"dark\", \"language\": \"en\"}"
}
```

```ruby
# Ruby usage
user_config = client.get_object_value("user-config", {})
# Returns: {"theme" => "dark", "language" => "en"}
```

This change ensures users understand the correct way to configure object types in AWS AppConfig while maintaining the provider's ease of use.
